### PR TITLE
Use randomUUID import in storage

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,6 +7,7 @@ import {
   type InsertPrompt,
   type InsertQuestionnaire,
 } from "@shared/schema";
+import { randomUUID } from 'crypto';
 import { db } from "./db";
 import { eq, desc } from "drizzle-orm";
 
@@ -60,7 +61,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createPrompt(prompt: InsertPrompt): Promise<{ id: string }> {
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     await db.insert(prompts).values({ ...prompt, id });
     return { id };
   }
@@ -75,7 +76,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createQuestionnaire(questionnaire: InsertQuestionnaire): Promise<{ id: string }> {
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     await db.insert(questionnaires).values({ ...questionnaire, id });
     return { id };
   }

--- a/zipped_git_folder/server/storage.ts
+++ b/zipped_git_folder/server/storage.ts
@@ -7,6 +7,7 @@ import {
   type InsertPrompt,
   type InsertQuestionnaire,
 } from "@shared/schema";
+import { randomUUID } from 'crypto';
 import { db } from "./db";
 import { eq, desc } from "drizzle-orm";
 
@@ -60,7 +61,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createPrompt(prompt: InsertPrompt): Promise<{ id: string }> {
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     await db.insert(prompts).values({ ...prompt, id });
     return { id };
   }
@@ -75,7 +76,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createQuestionnaire(questionnaire: InsertQuestionnaire): Promise<{ id: string }> {
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     await db.insert(questionnaires).values({ ...questionnaire, id });
     return { id };
   }


### PR DESCRIPTION
## Summary
- import `randomUUID` from `crypto`
- use the imported `randomUUID` instead of `crypto.randomUUID`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684d65a9b93c83269709e30fc5f9ec37