### PR TITLE
Handle Stripe webhook raw body

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,8 +3,15 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+// Skip body parsing for the Stripe webhook so the raw body is available
+app.use((req, res, next) => {
+  if (req.path === "/api/stripe-webhook") return next();
+  return express.json()(req, res, next);
+});
+app.use((req, res, next) => {
+  if (req.path === "/api/stripe-webhook") return next();
+  return express.urlencoded({ extended: false })(req, res, next);
+});
 
 app.use((req, res, next) => {
   const start = Date.now();


### PR DESCRIPTION
## Summary
- skip `express.json` and `express.urlencoded` for `/api/stripe-webhook`
- raw body is then available for Stripe signature verification

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684d8f5483c88326bb24d08072596a9c