### PR TITLE
Add configurable OpenRouter model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,5 @@ STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
 VITE_STRIPE_PUBLIC_KEY=pk_test_your_stripe_public_key_here
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 
-# Optional: Custom model configuration
+# Optional: Custom model configuration (defaults to 'mistralai/mistral-7b-instruct')
 # OPENROUTER_MODEL=mistralai/mistral-7b-instruct

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ REPLIT_DOMAINS=your-app-domain.replit.app
 
 # OpenRouter API (for AI functionality)
 OPENROUTER_API_KEY=your_openrouter_api_key
+# Optional: override the default model
+# OPENROUTER_MODEL=mistralai/mistral-7b-instruct
 
 # Stripe (for payments)
 STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
@@ -65,6 +67,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 2. Create an account
 3. Generate an API key from your dashboard
 4. Add it as `OPENROUTER_API_KEY` in your environment
+5. Optionally set `OPENROUTER_MODEL` to choose a different model (defaults to `mistralai/mistral-7b-instruct`)
 
 #### Stripe API Keys
 1. Go to [Stripe Dashboard](https://dashboard.stripe.com/apikeys)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 // Check for API keys with graceful fallbacks for preview mode
 const hasStripeKey = !!process.env.STRIPE_SECRET_KEY;
 const hasOpenRouterKey = !!process.env.OPENROUTER_API_KEY;
+const openRouterModel = process.env.OPENROUTER_MODEL || 'mistralai/mistral-7b-instruct';
 
 const stripe = hasStripeKey ? new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2023-10-16",
@@ -67,7 +68,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              model: 'mistralai/mistral-7b-instruct',
+              model: openRouterModel,
               messages: [
                 {
                   role: 'system',
@@ -171,7 +172,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              model: 'mistralai/mistral-7b-instruct',
+              model: openRouterModel,
               messages: [
                 {
                   role: 'system',


### PR DESCRIPTION
## Summary
- make OpenRouter model configurable via `OPENROUTER_MODEL` env var and use it in `server/routes.ts`
- document the new variable in `.env.example` and README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684d8f56712c8326a91f362ce80133f4