### PR TITLE
Fix crypto import usage

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   users,
   prompts,


### PR DESCRIPTION
## Summary
- import the crypto module for `randomUUID`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684d9a8a57e88326809639463ae68b70