### PR TITLE
Handle Stripe payment success webhook

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15,6 +15,7 @@ export interface IStorage {
   // User operations
   // (IMPORTANT) these user operations are mandatory for Replit Auth.
   getUser(id: string): Promise<User | undefined>;
+  getUserBySubscriptionId(subscriptionId: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
   
   // Prompt operations
@@ -41,6 +42,14 @@ export class DatabaseStorage implements IStorage {
 
   async getUser(id: string): Promise<User | undefined> {
     const [user] = await db.select().from(users).where(eq(users.id, id));
+    return user;
+  }
+
+  async getUserBySubscriptionId(subscriptionId: string): Promise<User | undefined> {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.stripeSubscriptionId, subscriptionId));
     return user;
   }
 


### PR DESCRIPTION
## Summary
- add `getUserBySubscriptionId` to storage
- update the Stripe webhook handler to reset usage on payment success

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_684d9a8c35988326a441e188d7a2e6fa